### PR TITLE
Add an ENTRYPOINT to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,3 +62,5 @@ RUN pip install minus80 locuspocus
 
 COPY . /home/RNAMapping 
 WORKDIR /home/RNAMapping
+
+ENTRYPOINT ["/usr/bin/zsh"]


### PR DESCRIPTION
Adding an `ENTRYPOINT` tells docker where to "start" when the container is running. It appears that without an entrypoint, it defaults to `bash`.

You could also specify a command to run when you start docker:
```
docker build -t index:latest .
docker run -it index:latest zsh
```
which would also start up ZSH in the running container.